### PR TITLE
docs: correct url for the git clone guide in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Built-in feature from Next.js:
 Run the following command on your local environment:
 
 ```shell
-git clone --depth=1 https://github.com/ixartz/Next-js-Boilerplate.git my-project-name
+git clone --depth=1 https://github.com/ixartz/SaaS-Boilerplate.git my-project-name
 cd my-project-name
 npm install
 ```


### PR DESCRIPTION
Corrects the README guide to utilize the SaaS boilerplate url instead of NextJs boilerplate.