### PR TITLE
feat: add S3 file upload support via pushduck

### DIFF
--- a/.env
+++ b/.env
@@ -17,11 +17,21 @@ NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_test_51PNk4fKOp3DEwzQle6Cx1j3IW1Lze5nFKZ4J
 # Use Stripe test mode price id or production price id
 BILLING_PLAN_ENV=dev
 
+# File Uploads (pushduck — https://github.com/abhay-ramesh/pushduck)
+# Add your AWS S3 (or compatible) credentials below.
+# For Cloudflare R2: change provider to "cloudflareR2" and add CLOUDFLARE_ACCOUNT_ID
+AWS_S3_REGION=us-east-1
+
 ######## [BEGIN] SENSITIVE DATA ######## For security reason, don't update the following variables (secret key) directly in this file.
 ######## Please create a new file named `.env.local`, all environment files ending with `.local` won't be tracked by Git.
 ######## After creating the file, you can add the following variables.
 # Clerk authentication
 CLERK_SECRET_KEY=your_clerk_secret_key
+
+# File Uploads — sensitive credentials (add to .env.local, never commit)
+AWS_S3_ACCESS_KEY_ID=your_aws_access_key_id
+AWS_S3_SECRET_ACCESS_KEY=your_aws_secret_access_key
+AWS_S3_BUCKET_NAME=your_s3_bucket_name
 
 # Stripe
 STRIPE_SECRET_KEY=your_stripe_secret_key

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "next-themes": "^0.3.0",
     "pg": "^8.13.0",
     "pino": "^9.5.0",
+    "pushduck": "^0.4.0",
     "pino-pretty": "^11.3.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -1,0 +1,43 @@
+import { auth } from '@clerk/nextjs/server';
+import { createUploadConfig } from 'pushduck/server';
+
+const { s3 } = createUploadConfig()
+  .provider('aws', {
+    accessKeyId: process.env.AWS_S3_ACCESS_KEY_ID!,
+    secretAccessKey: process.env.AWS_S3_SECRET_ACCESS_KEY!,
+    region: process.env.AWS_S3_REGION!,
+    bucket: process.env.AWS_S3_BUCKET_NAME!,
+  })
+  .paths({
+    prefix: 'uploads',
+    generateKey: (file, metadata) => {
+      const userId = (metadata as { userId?: string }).userId ?? 'anonymous';
+      const timestamp = Date.now();
+      return `${userId}/${timestamp}/${file.name}`;
+    },
+  })
+  .build();
+
+const uploadRouter = s3.createRouter({
+  imageUpload: s3
+    .image()
+    .maxFileSize('4MB')
+    .formats(['jpeg', 'jpg', 'png', 'gif', 'webp'])
+    .middleware(async () => {
+      const { userId } = await auth();
+      if (!userId) throw new Error('Unauthorized');
+      return { userId };
+    }),
+  documentUpload: s3
+    .file()
+    .maxFileSize('16MB')
+    .middleware(async () => {
+      const { userId } = await auth();
+      if (!userId) throw new Error('Unauthorized');
+      return { userId };
+    }),
+});
+
+export type AppUploadRouter = typeof uploadRouter;
+
+export const { GET, POST } = uploadRouter.handlers;

--- a/src/components/FileUpload.tsx
+++ b/src/components/FileUpload.tsx
@@ -1,0 +1,200 @@
+'use client';
+
+import { useRef } from 'react';
+import { createUploadClient } from 'pushduck/client';
+
+import type { AppUploadRouter } from '@/app/api/upload/route';
+
+const upload = createUploadClient<AppUploadRouter>({
+  endpoint: '/api/upload',
+});
+
+function UploadProgress({ progress }: { progress: number }) {
+  return (
+    <div className="mt-1 h-1.5 w-full overflow-hidden rounded-full bg-gray-200">
+      <div
+        className="h-full rounded-full bg-blue-600 transition-all duration-300"
+        style={{ width: `${progress}%` }}
+      />
+    </div>
+  );
+}
+
+export function ImageUpload() {
+  const { uploadFiles, files, isUploading, reset } = upload.imageUpload();
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  return (
+    <div className="space-y-4">
+      <div
+        role="button"
+        tabIndex={0}
+        className="cursor-pointer rounded-lg border-2 border-dashed border-gray-300 p-8 text-center transition-colors hover:border-blue-500"
+        onClick={() => inputRef.current?.click()}
+        onKeyDown={e => e.key === 'Enter' && inputRef.current?.click()}
+      >
+        <input
+          ref={inputRef}
+          type="file"
+          accept="image/*"
+          multiple
+          className="hidden"
+          onChange={(e) => {
+            const selected = Array.from(e.target.files ?? []);
+            if (selected.length) uploadFiles(selected);
+          }}
+          disabled={isUploading}
+        />
+        <p className="text-sm text-gray-500">
+          {isUploading
+            ? 'Uploading...'
+            : 'Click to upload images (JPEG, PNG, GIF, WebP — max 4\u202fMB each)'}
+        </p>
+      </div>
+
+      {files.length > 0 && (
+        <ul className="space-y-2">
+          {files.map(file => (
+            <li
+              key={file.id}
+              className="flex items-start gap-3 rounded-lg border border-gray-200 p-3"
+            >
+              <div className="min-w-0 flex-1">
+                <p className="truncate text-sm font-medium text-gray-900">
+                  {file.name}
+                </p>
+                {file.status === 'uploading' && (
+                  <UploadProgress progress={file.progress} />
+                )}
+                {file.status === 'success' && file.url && (
+                  <a
+                    href={file.url}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="mt-0.5 block truncate text-xs text-blue-600 hover:underline"
+                  >
+                    {file.url}
+                  </a>
+                )}
+                {file.status === 'error' && (
+                  <p className="mt-0.5 text-xs text-red-600">
+                    {file.error ?? 'Upload failed'}
+                  </p>
+                )}
+              </div>
+              <span
+                className={`shrink-0 rounded-full px-2 py-0.5 text-xs font-medium ${
+                  file.status === 'success'
+                    ? 'bg-green-100 text-green-700'
+                    : file.status === 'error'
+                      ? 'bg-red-100 text-red-700'
+                      : 'bg-gray-100 text-gray-600'
+                }`}
+              >
+                {file.status === 'uploading'
+                  ? `${file.progress}%`
+                  : file.status}
+              </span>
+            </li>
+          ))}
+          <button
+            type="button"
+            onClick={reset}
+            className="text-xs text-gray-500 underline hover:text-gray-700"
+          >
+            Clear all
+          </button>
+        </ul>
+      )}
+    </div>
+  );
+}
+
+export function DocumentUpload() {
+  const { uploadFiles, files, isUploading, reset } = upload.documentUpload();
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  return (
+    <div className="space-y-4">
+      <div
+        role="button"
+        tabIndex={0}
+        className="cursor-pointer rounded-lg border-2 border-dashed border-gray-300 p-8 text-center transition-colors hover:border-blue-500"
+        onClick={() => inputRef.current?.click()}
+        onKeyDown={e => e.key === 'Enter' && inputRef.current?.click()}
+      >
+        <input
+          ref={inputRef}
+          type="file"
+          multiple
+          className="hidden"
+          onChange={(e) => {
+            const selected = Array.from(e.target.files ?? []);
+            if (selected.length) uploadFiles(selected);
+          }}
+          disabled={isUploading}
+        />
+        <p className="text-sm text-gray-500">
+          {isUploading
+            ? 'Uploading...'
+            : 'Click to upload files (any type — max 16\u202fMB each)'}
+        </p>
+      </div>
+
+      {files.length > 0 && (
+        <ul className="space-y-2">
+          {files.map(file => (
+            <li
+              key={file.id}
+              className="flex items-start gap-3 rounded-lg border border-gray-200 p-3"
+            >
+              <div className="min-w-0 flex-1">
+                <p className="truncate text-sm font-medium text-gray-900">
+                  {file.name}
+                </p>
+                {file.status === 'uploading' && (
+                  <UploadProgress progress={file.progress} />
+                )}
+                {file.status === 'success' && file.url && (
+                  <a
+                    href={file.url}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="mt-0.5 block truncate text-xs text-blue-600 hover:underline"
+                  >
+                    {file.url}
+                  </a>
+                )}
+                {file.status === 'error' && (
+                  <p className="mt-0.5 text-xs text-red-600">
+                    {file.error ?? 'Upload failed'}
+                  </p>
+                )}
+              </div>
+              <span
+                className={`shrink-0 rounded-full px-2 py-0.5 text-xs font-medium ${
+                  file.status === 'success'
+                    ? 'bg-green-100 text-green-700'
+                    : file.status === 'error'
+                      ? 'bg-red-100 text-red-700'
+                      : 'bg-gray-100 text-gray-600'
+                }`}
+              >
+                {file.status === 'uploading'
+                  ? `${file.progress}%`
+                  : file.status}
+              </span>
+            </li>
+          ))}
+          <button
+            type="button"
+            onClick={reset}
+            className="text-xs text-gray-500 underline hover:text-gray-700"
+          >
+            Clear all
+          </button>
+        </ul>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Adds presigned URL-based file uploads via [pushduck](https://github.com/abhay-ramesh/pushduck) (v0.4.0) — files go directly from the browser to S3, so **no server bandwidth is consumed**
- Integrates with **Clerk v6 auth** (`auth()` from `@clerk/nextjs/server`) — all upload routes are protected and scoped per user
- Supports **AWS S3, Cloudflare R2, DigitalOcean Spaces, and MinIO** out of the box by swapping the `provider()` call

## What's added

### `src/app/api/upload/route.ts`
The upload API route that creates a typed upload router with two endpoints:
- `imageUpload` — accepts JPEG, PNG, GIF, WebP up to 4 MB; requires auth
- `documentUpload` — accepts any file type up to 16 MB; requires auth

Files are stored at `uploads/{userId}/{timestamp}/{filename}` in the configured bucket.

### `src/components/FileUpload.tsx`
Two ready-to-use React components (`ImageUpload` and `DocumentUpload`) with:
- Click-to-upload drag zone
- Per-file progress bars
- Status badges (uploading / success / error)
- Clickable URLs on success
- "Clear all" button

### `package.json`
Added `"pushduck": "^0.4.0"` to dependencies.

### `.env`
Added the required environment variable keys (safe non-secret values committed; secrets documented for `.env.local`).

## Environment variables needed

Add these to `.env.local` (never commit secrets):

```
AWS_S3_ACCESS_KEY_ID=your_key
AWS_S3_SECRET_ACCESS_KEY=your_secret
AWS_S3_REGION=us-east-1         # already in .env as a default
AWS_S3_BUCKET_NAME=your_bucket
```

For **Cloudflare R2**, change the provider in `route.ts`:
```ts
.provider('cloudflareR2', {
  accountId: process.env.CLOUDFLARE_ACCOUNT_ID!,
  accessKeyId: process.env.AWS_S3_ACCESS_KEY_ID!,
  secretAccessKey: process.env.AWS_S3_SECRET_ACCESS_KEY!,
  bucket: process.env.AWS_S3_BUCKET_NAME!,
})
```

## Usage example

```tsx
import { ImageUpload, DocumentUpload } from '@/components/FileUpload';

// In any authenticated page/component:
<ImageUpload />
<DocumentUpload />
```

## Test plan

- [ ] Set the four `AWS_S3_*` env vars in `.env.local`
- [ ] Run `npm install` to pull in `pushduck`
- [ ] Start the dev server (`npm run dev`) and sign in
- [ ] Navigate to a page that renders `<ImageUpload />` or `<DocumentUpload />`
- [ ] Upload a file and confirm the presigned-URL flow completes without errors
- [ ] Verify the file appears in the S3 bucket under `uploads/{userId}/...`
- [ ] Confirm that unauthenticated requests to `/api/upload` are rejected with 401

🤖 Generated with [Claude Code](https://claude.com/claude-code)