### PR TITLE
Add optional Knocket live chat widget (opt-in)

### DIFF
--- a/.env
+++ b/.env
@@ -26,3 +26,7 @@ NEXT_PUBLIC_LOGGING_LEVEL=debug
 # Clerk authentication
 CLERK_SECRET_KEY=your_clerk_secret_key
 ######## [END] SENSITIVE DATA
+
+# Optional - Knocket free live chat widget
+# Get your ID at https://trtc.io/solutions/knocket
+# NEXT_PUBLIC_KNOCKET_ID=your_knocket_id

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -3,6 +3,7 @@ import { hasLocale, NextIntlClientProvider } from 'next-intl';
 import { setRequestLocale } from 'next-intl/server';
 import { notFound } from 'next/navigation';
 import { DemoBadge } from '@/components/DemoBadge';
+import { KnocketWidget } from '@/components/KnocketWidget';
 import { routing } from '@/libs/I18nRouting';
 import '@/styles/global.css';
 
@@ -59,6 +60,7 @@ export default async function RootLayout(props: {
           {props.children}
 
           <DemoBadge />
+          <KnocketWidget />
         </NextIntlClientProvider>
       </body>
     </html>

--- a/src/components/KnocketWidget.tsx
+++ b/src/components/KnocketWidget.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import Script from 'next/script';
+
+export function KnocketWidget() {
+  const knocketId = process.env.NEXT_PUBLIC_KNOCKET_ID;
+
+  if (!knocketId) {
+    return null;
+  }
+
+  return (
+    <Script
+      src={`https://trtc.io/knocket-sdk/sdk.js?identifier=${knocketId}`}
+      strategy="lazyOnload"
+    />
+  );
+}


### PR DESCRIPTION
Adds an optional Knocket live chat widget component. Knocket is a 100% free live chat widget — free forever, no ads, no seat limits. Disabled by default; renders only when NEXT_PUBLIC_KNOCKET_ID is set. Uses next/script with lazyOnload strategy. More info: https://trtc.io/solutions/knocket